### PR TITLE
fix: Clean up C++ post categories and frontmatter

### DIFF
--- a/_posts/2025-07-04-22.-c++-preprocessors.md
+++ b/_posts/2025-07-04-22.-c++-preprocessors.md
@@ -1,17 +1,11 @@
 ---
-date: 2025-07-04 02:00:00 +0000
-categories:
-  - Programming
-  - CPP Programming
-  - Preprocessor
-tags: "22. C++ Preprocessors"
+title: "22. C++ Preprocessors"
 description: "🚀 Master C++ preprocessors!  Learn about directives, #include, #define, conditional compilation, and their differences from function templates.  Become a more efficient C++ programmer! 🚀"
 author: infoyouth
 date: 2025-07-04 02:00:00 +0000
 categories:
   - Programming
-  - C++
-  - Preprocessing
+  - CPP Programming
 tags:
   - "C++ Preprocessor"
   - "#include"

--- a/_posts/2025-07-07-23.-c++-namespace.md
+++ b/_posts/2025-07-07-23.-c++-namespace.md
@@ -1,17 +1,11 @@
 ---
-date: 2025-07-07 02:00:00 +0000
-categories:
-  - Programming
-  - CPP Programming
-  - Namespace
-tags: "23. C++ Namespace"
+title: "23. C++ Namespace"
 description: "🚀 Master C++ namespaces!  This tutorial unlocks the power of namespaces, covering creation, access, nesting, aliasing, and inline namespaces – improving code organization and preventing naming conflicts.  Learn to write cleaner, more maintainable C++ code! ✨"
 author: infoyouth
 date: 2025-07-07 02:00:00 +0000
 categories:
   - Programming
-  - C++
-  - C++ Namespaces
+  - CPP Programming
 tags:
   - "C++"
   - "Namespaces"

--- a/_posts/2025-07-13-25.-c-vs-c++.md
+++ b/_posts/2025-07-13-25.-c-vs-c++.md
@@ -6,7 +6,6 @@ date: 2025-07-13 02:00:00 +0000
 categories:
   - Programming
   - CPP Programming
-  - Language Comparison
 tags:
   - C
   - C++

--- a/_posts/2025-07-16-26.-c++-vs-java.md
+++ b/_posts/2025-07-16-26.-c++-vs-java.md
@@ -5,9 +5,7 @@ author: infoyouth
 date: 2025-07-16 02:00:00 +0000
 categories:
   - Programming
-  - Language Comparison
   - CPP Programming
-  - Java
 tags:
   - C++
   - Java

--- a/_posts/2025-07-19-27.-competitive-programming-in-c++.md
+++ b/_posts/2025-07-19-27.-competitive-programming-in-c++.md
@@ -5,7 +5,6 @@ author: infoyouth
 date: 2025-07-19 02:00:00 +0000
 categories:
   - Programming
-  - Competitive Programming
   - CPP Programming
 tags:
   - Competitive Programming


### PR DESCRIPTION
- Removed 'Language Comparison' category (merged to CPP Programming)
- Removed 'Competitive Programming' category (merged to CPP Programming)
- Fixed duplicate frontmatter in namespace and preprocessors posts
- Standardized all C++ posts to use 'CPP Programming'
- All mermaid diagrams verified and working

Modified files:
- 2025-07-04-22.-c++-preprocessors.md
- 2025-07-07-23.-c++-namespace.md
- 2025-07-13-25.-c-vs-c++.md
- 2025-07-16-26.-c++-vs-java.md
- 2025-07-19-27.-competitive-programming-in-c++.md