### PR TITLE
fix: Correct workflow name and add manual trigger for testing

### DIFF
--- a/.github/workflows/social-publish.yml
+++ b/.github/workflows/social-publish.yml
@@ -4,10 +4,16 @@ name: 📢 Social Media Auto-Publisher
 # Trigger after successful deployment
 "on":
   workflow_run:
-    workflows: ["Deploy"]
+    workflows: ["🚧 Build Test and Deploy"]
     types: [completed]
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      post_file:
+        description: 'Path to the blog post file (e.g., _posts/python/2025-11-06-10.-python-functions---advanced.md)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -15,8 +21,8 @@ permissions:
 jobs:
   detect-and-publish:
     name: 🔍 Detect New Posts & Publish
-    # Only run if deploy succeeded
-    if: github.event.workflow_run.conclusion == 'success'
+    # Only run if deploy succeeded OR manually triggered
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04
 
     steps:
@@ -28,6 +34,22 @@ jobs:
       - name: 🔍 Detect NEW Posts (Added, Not Modified)
         id: detect
         run: |
+          # Manual trigger mode - use provided post file
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            POST_FILE="${{ github.event.inputs.post_file }}"
+            echo "🎯 Manual trigger mode - using specified post: ${POST_FILE}"
+            
+            if [ ! -f "$POST_FILE" ]; then
+              echo "❌ Error: File not found: ${POST_FILE}"
+              exit 1
+            fi
+            
+            echo "post_file=${POST_FILE}" >> $GITHUB_OUTPUT
+            echo "has_new_posts=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          # Automatic mode - detect new posts from git diff
           echo "🔎 Checking for newly added markdown files..."
           
           # Get list of NEW files added in last commit (status 'A' = Added)


### PR DESCRIPTION
- Fixed workflow_run trigger from 'Deploy' to '🚧 Build Test and Deploy'
- Added workflow_dispatch for manual testing without needing new posts
- Updated detection logic to handle both automatic and manual modes

This enables:
1. Automatic social publishing when new posts are merged to main
2. Manual testing by running workflow with any existing post file